### PR TITLE
lighttpd 1.4.78 refresh

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,3 +1,3 @@
 sources:
-  lighttpd-1.4.74.tar.xz: 26e752ca533e51376e5e93dc1573efd4e2d59dd8
-  lighttpd-1.4.74.tar.xz.asc: 368b8477b6d5a588d0662e890c5d0b01469b2b21
+  lighttpd-1.4.78.tar.xz: 9f92446dcd5a27484e89f92e592cf1824257b217
+  lighttpd-1.4.78.tar.xz.asc: 3f7af59829981b7d555b4ec887c14000bf64527b

--- a/lighttpd-defaultroot.patch
+++ b/lighttpd-defaultroot.patch
@@ -1,11 +1,11 @@
---- doc/config/lighttpd.conf.defaultroot	2011-12-02 09:31:24.196527335 +0800
-+++ doc/config/lighttpd.conf	2011-12-02 09:31:31.196529178 +0800
+--- doc/config/lighttpd.annotated.conf.defaultroot	2011-12-02 09:31:24.196527335 +0800
++++ doc/config/lighttpd.annotated.conf	2011-12-02 09:31:31.196529178 +0800
 @@ -14,7 +14,7 @@
- ## chroot example aswell.
+ ## chroot example as well.
  ##
  var.log_root    = "/var/log/lighttpd"
 -var.server_root = "/srv/www"
 +var.server_root = "/var/www"
- var.state_dir   = "/var/run"
+ var.state_dir   = "/run"
  var.home_dir    = "/var/lib/lighttpd"
  var.conf_dir    = "/etc/lighttpd"

--- a/lighttpd.service
+++ b/lighttpd.service
@@ -1,14 +1,17 @@
 [Unit]
-Description=Lightning Fast Webserver With Light System Requirements
-After=syslog.target network.target
+Description=Lighttpd Daemon
+After=network-online.target
+Documentation=man:lighttpd https://wiki.lighttpd.net
 
 [Service]
 Type=simple
-PIDFile=/var/run/lighttpd.pid
+PIDFile=/run/lighttpd.pid
 EnvironmentFile=-/etc/sysconfig/lighttpd
 ExecStartPre=/usr/sbin/lighttpd -tt -f /etc/lighttpd/lighttpd.conf
 ExecStart=/usr/sbin/lighttpd -D -f /etc/lighttpd/lighttpd.conf
+ExecReload=/usr/sbin/lighttpd -tt -f /etc/lighttpd/lighttpd.conf
 ExecReload=/bin/kill -USR1 $MAINPID
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
lighttpd 1.4.78 refresh

- update to lighttpd 1.4.78
- change /var/run to /run
- lighttpd.spec update for lighttpd.annotated.conf
- lighttpd.spec lighttpd package includes all .so except those excluded
- lighttpd.spec package separation for mod_deflate, mod_openssl
- systemd lighttpd.service additions

Note: **UNTESTED**

@AngryPenguinPL please review commits aimed at refreshing the lighttpd config spec. Thanks.

Reference: https://src.fedoraproject.org/rpms/lighttpd/tree/rawhide

This PR is similar to #4 from a few years ago.

Not addressed in this PR: OpenMandrivaAssociation lighttpd packages still differ from other RedHat/Fedora-based lighttpd.spec in that OpenMandrivaAssociation lighttpd packages are missing some packages and optional features of lighttpd (such as lighttpd mod_deflate brotli and zstd support), alternative lighttpd TLS modules besides openssl, and alternative lighttpd mod_authn_* and lighttpd mod_vhostdb_* modules.